### PR TITLE
MC_Test fixed

### DIFF
--- a/src/main/java/MC_Test.java
+++ b/src/main/java/MC_Test.java
@@ -61,9 +61,12 @@ public class MC_Test implements PlugIn {
 		int threshold = 120;
 		BranchGroup scene = univ.getScene();
 		for(int i = scene.numChildren()-1; i >= 1 ; i--) {
-			scene.removeChild(i);
+			if (scene.getChild(i) instanceof BranchGroup)
+				if (scene.getChild(i).getCapability(BranchGroup.ALLOW_DETACH))
+					scene.removeChild(i);
 		}
-		
+		System.out.println("Nr. of contents:" + univ.getContents().size());
+		univ.removeAllContents();
 		createCase(caseNo);
 		Volume volume = new Volume(image);
 		List l = MCCube.getTriangles(volume, threshold);


### PR DESCRIPTION
The test plugin for 3Dviewer "Test Marching Cube" returns the following error: 

```
javax.media.j3d.CapabilityNotSetException: Group: no capability to detach BranchGroup
at javax.media.j3d.Group.removeChild(Group.java:225)
at MC_Test.displayCase(MC_Test.java:64)
at MC_Test.run(MC_Test.java:42)
at ij.IJ.runUserPlugIn(IJ.java:202)
at ij.IJ.runPlugIn(IJ.java:166)
at ij.Executer.runCommand(Executer.java:131)
at ij.Executer.run(Executer.java:64)
at java.lang.Thread.run(Thread.java:695)
```

The fix was made as follows: In the method `displayCase`, removal of `BranchGroups` is now done only after checking:
1. If the child object is an instance of `BranchGroup` 
2. If the child object is detachable. 

After fixing the above problem and successfully running the plugin, there was another small bug that caused repetitive warning message "Case X already exists". This was because as added contents were never removed from the Universe, they collide with new content with the same name.   This was fixed by adding a line to remove all contents before adding a new Mesh content.
